### PR TITLE
PORT-8749: Replace tenant name in docsCount

### DIFF
--- a/scripts/service.js
+++ b/scripts/service.js
@@ -372,6 +372,7 @@ async function updateTenantJSONFile() {
     tenant_Data.product.documentation = `/v1/docs/${yamlData.Tenant_Name}`;
     tenant_Data.product.documenttree = `/v1/docs/${yamlData.Tenant_Name}`;
     tenant_Data.product.documenttreeV2 = `/v2/docs/${yamlData.Tenant_Name}`;
+    tenant_Data.product.docsCount = `/v2/docs/count/${yamlData.Tenant_Name}`;
     tenant_Data.product.sandbox = `/v2/sandboxrun/${yamlData.Tenant_Name}`;
     tenant_Data.product.accessConfig = `/v1/fileAccess/${yamlData.Tenant_Name}`;
     tenant_Data.product.assets = `/v1/assets/${yamlData.Tenant_Name}`;


### PR DESCRIPTION
Replace the tenant name in `/v2/docs/count/<name_of_tenant>`