### PR TITLE
PORT-9636: Upload `ruleset update` script

### DIFF
--- a/tenant-config-scripts/README.md
+++ b/tenant-config-scripts/README.md
@@ -145,3 +145,34 @@ python3 tenant-config-scripts/githubBranches.py
 ```
 
 A commented out curl command is also placed at the bottom of the script for reference.
+
+## rulesetUpdate.py
+
+Script to parse through an organization's repositories and mass update branch protection Ruleset to change various rules as needed. This script updates the `status_checks` rules.
+
+- Utilizes `python3` so make sure you have it installed
+- Will require a personal access token with proper organization/project read-write permissions to modify configs
+
+### Variables
+
+- `token`: Github access token - variable `<Github_Access_Token>` will need to be replaced with proper data
+   - Should be saved in Github secret if we want to utilize pipeline
+   - If running locally, you will need to generate your own access token with proper permission
+- `org_name`: Name for Github organization/project owner you'd like to make changes for
+- `ruleset`: Configs for the Ruleset being updated, check [Ruleset Reference](https://docs.github.com/en/rest/repos/rules?apiVersion=2022-11-28#create-a-repository-ruleset) for more details
+- `headers`: Default headers as provided by Github API
+
+For testing, replace `repositories` variable with a list containing a single tenant before the for-loop or modify the for-loop itself:
+   - ```Python 
+     repositories = ["Test-repo"]
+     for repo in repositories:
+     ```
+   - ```Python 
+     for repo in ["Test-repo"]:
+     ```
+
+### Usage
+
+``` Bash
+python3 tenant-config-scripts/rulesetUpdate.py
+```

--- a/tenant-config-scripts/rulesetUpdate.py
+++ b/tenant-config-scripts/rulesetUpdate.py
@@ -1,0 +1,103 @@
+import requests
+
+''' --- Variables --- '''
+
+# Github Access Token
+token = "<Github_Access_Token>"
+
+# Organization Name
+org_name = "Fiserv"
+
+# Branch protection settings
+ruleset = {
+  "rules": [
+    {
+      "type": "update",
+      "parameters": {
+        "update_allows_fetch_and_merge": True
+      }
+    },
+    {
+      "type": "deletion",
+      "parameters": None
+    },
+    {
+      "type": "non_fast_forward",
+      "parameters": None
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "dismiss_stale_reviews_on_push": False,
+        "require_code_owner_review": False,
+        "require_last_push_approval": True,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": True
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": False,
+        "required_status_checks": [
+          {
+            "context": "validator / api_validator / api_validator_actions"
+          },
+          {
+            "context": "validator / tenant-config-validator / Tenant-Config-Action"
+          }
+        ]
+      }
+    }
+  ]
+}
+
+headers = {
+  "Authorization": f"token {token}",
+  "Accept": "application/vnd.github+json",
+  "X-GitHub-Api-Version": "2022-11-28"
+}
+
+def getRepos() -> list:  
+# Fetch repositories in the project
+  url = f"https://api.github.com/orgs/{org_name}/repos"
+  response = requests.get(url, params={"per_page": 100}, headers=headers)
+
+  # Process the response
+  if response.status_code == 200 and len(response.json()) > 0:
+    repositories = [repo['name'] for repo in response.json()]
+    print(repositories)
+    return repositories
+  else:
+    print("Failed to fetch repositories from the project.")
+    exit()
+
+def getRulesetID(repo:str) -> int:   
+  # Fetch repositories in the project
+  url = f"https://api.github.com/repos/{org_name}/{repo}/rulesets"
+  response = requests.get(url, headers=headers)
+
+  # Process the response
+  if response.status_code == 200:
+    print(f"Updating {response.json()[0]['name']}")
+    return response.json()[0]['id']
+  else:
+    print(f"Failed to fetch {repo}'s ruleset.")
+    print(response.json())
+
+''' --- Script Execution --- '''
+
+repositories = getRepos()
+for repo in repositories:
+  ruleset_id = getRulesetID(repo)
+  if ruleset_id is None:
+    continue
+
+  url = f"https://api.github.com/repos/{org_name}/{repo}/rulesets/{ruleset_id}"
+  response = requests.put(url, json=ruleset, headers=headers)
+
+  if response.status_code == 200 or response.status_code == 201:
+    print(f"GitHub ruleset updated for {repo}.")
+  else:
+    print(f"Failed to update GitHub ruleset for {repo}.")
+    print(response.json())

--- a/tenant-config-scripts/rulesetUpdate.py
+++ b/tenant-config-scripts/rulesetUpdate.py
@@ -12,12 +12,6 @@ org_name = "Fiserv"
 ruleset = {
   "rules": [
     {
-      "type": "update",
-      "parameters": {
-        "update_allows_fetch_and_merge": True
-      }
-    },
-    {
       "type": "deletion",
       "parameters": None
     },


### PR DESCRIPTION
Python script for updating all repositories' Ruleset with new set of rules.

We removed the requirement for them to pull to feature branch before attempting to merge (i.e. merge stage into develop_feature_branch then merge). This should allow them to merge directly from develop -> stage and also remove confusion revolving around having to click the Update branch button.