### PR TITLE
Default `betaTag` to `false`

### DIFF
--- a/src/dbscripts.rs
+++ b/src/dbscripts.rs
@@ -237,7 +237,7 @@ pub fn create_dbscripts(execute: bool, yaml: &Vec<Yaml>, env_flag: String) {
     },    
   ],   
   active: true,
-  betaTag: true,
+  betaTag: false,
   internalTag: "+ if *internal_tag { concat!(true) } else { concat!(false)}+",
   github: '" + &github_repo_name + "',
   selfServiceFeatures: [


### PR DESCRIPTION
As per Cathy and new implementation, tenants should only have the betaTag if they would like a blue `beta` tag next to their name. This field isn't being used otherwise.